### PR TITLE
Add rosbag extraction utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,24 +51,23 @@ Documentation for the functions are provided by the code. The los (line of sight
 ### Utilities
 * explore: A simple workspace script to use and inspect the derived data, step by step.
 
-### Dataset létrehozása rosbagből
-Az alábbi lépések segítenek egy rosbag állományból olyan nyers adatkészletet előállítani, amelyet a StixelGENerator képes feldolgozni.
+### Creating a dataset from rosbag
+The following steps show how to extract a raw dataset from a rosbag so that it can be processed by StixelGENerator.
 
-1. **Rosbag konvertálása**
-   Ha a felvétel ROS1 formátumú, először konvertáld ROS2 baggé:
+1. **Convert the rosbag**
+   If your recording is in ROS1 format, convert it to ROS2 first:
    ```bash
    ros2 bag convert input.bag -o output_bag
    ```
 
-2. **A bag tartalmának ellenőrzése**
-   A `.db3` adatbázisban tárolt topikok listázása például az alábbi paranccsal lehetséges:
+2. **Inspect the bag contents**
+   List the available topics stored in the `.db3` database:
    ```bash
    sqlite3 output_bag.db3 "SELECT name FROM topics;"
    ```
 
-3. **Üzenetek kinyerése**
-   A `utility/rosbag_to_dataset.py` szkript képes a kiválasztott kép- és pontfelhő
-   topikokból fájlokat generálni. Például ZED2i bal kamera és Ouster LiDAR esetén:
+3. **Extract messages**
+   Use the `utility/rosbag_to_dataset.py` script to export files from the chosen image and point cloud topics. For example with a ZED2i left camera and an Ouster LiDAR:
    ```bash
    python utility/rosbag_to_dataset.py \
        --db output_bag.db3 \
@@ -76,23 +75,16 @@ Az alábbi lépések segítenek egy rosbag állományból olyan nyers adatkészl
        --pc_topic /ouster/points \
        --out dataset_raw
    ```
-   A kimenetként létrejövő `dataset_raw/images` és `dataset_raw/pointclouds`
-   könyvtárakban JPEG képek és CSV formátumú pontfelhők lesznek elhelyezve.
+   The resulting `dataset_raw/images` and `dataset_raw/pointclouds` directories will contain JPEG images and CSV point clouds.
 
-4. **Kompatibilitás ellenőrzése**
-   A StixelGENerator Dataloader a JPEG képeket és a `x,y,z` koordinátákat tartalmazó
-   CSV-ket is képes kezelni, ha a kalibrációs mátrixok elérhetők. Ellenőrizd, hogy
-   mindkét mappában azonos számú fájl keletkezett, illetve hogy a pontfelhők a
-   szenzor specifikációinak megfelelően vannak kinyerve.
+4. **Verify compatibility**
+   StixelGENerator's dataloaders can read JPEG images and `x,y,z` CSV files when calibration matrices are provided. Check that both folders contain the same number of files and that the point clouds are correctly extracted for your sensor.
 
-5. **Kalibrációk hozzáadása**
-   A generáláshoz szükséges a kamera–LiDAR kalibráció (K, P, extrinsic). Ezeket a
-   rosbagből vagy a használt szenzorrendszer dokumentációjából kell kinyerni, és
-   a saját adatbetöltőben felhasználni.
+5. **Add calibrations**
+   Camera–LiDAR calibration (K, P and extrinsic) must be obtained from the rosbag or your sensor setup and integrated in your custom dataloader.
 
-6. **Stixel világ előállítása**
-   A `config.yaml`-ban add meg az új adatútvonalat, majd indítsd el a
-   generálást:
+6. **Generate Stixel Worlds**
+   Configure the new data path in `config.yaml` and start the generation:
    ```bash
    python generate.py
    ```

--- a/README.md
+++ b/README.md
@@ -50,3 +50,43 @@ Documentation for the functions are provided by the code. The los (line of sight
 
 ### Utilities
 * explore: A simple workspace script to use and inspect the derived data, step by step.
+
+### Dataset létrehozása rosbagből
+Az alábbi lépések segítenek egy rosbag állományból olyan nyers adatkészletet előállítani, amelyet a StixelGENerator képes feldolgozni.
+
+1. **Rosbag konvertálása**
+   Ha a felvétel ROS1 formátumú, először konvertáld ROS2 baggé:
+   ```bash
+   ros2 bag convert input.bag -o output_bag
+   ```
+
+2. **A bag tartalmának ellenőrzése**
+   A `.db3` adatbázisban tárolt topikok listázása például az alábbi paranccsal lehetséges:
+   ```bash
+   sqlite3 output_bag.db3 "SELECT name FROM topics;"
+   ```
+
+3. **Üzenetek kinyerése**
+   A `utility/rosbag_to_dataset.py` szkript képes a kiválasztott kép- és pontfelhő
+   topikokból fájlokat generálni:
+   ```bash
+   python utility/rosbag_to_dataset.py \
+       --db output_bag.db3 \
+       --image_topic /camera/image/compressed \
+       --pc_topic /lidar/points \
+       --out dataset_raw
+   ```
+   A kimenetként létrejövő `dataset_raw/images` és `dataset_raw/pointclouds`
+   könyvtárakban JPEG képek és CSV formátumú pontfelhők lesznek elhelyezve.
+
+4. **Kalibrációk hozzáadása**
+   A generáláshoz szükséges a kamera–LiDAR kalibráció (K, P, extrinsic). Ezeket a
+   rosbagből vagy a használt szenzorrendszer dokumentációjából kell kinyerni, és
+   a saját adatbetöltőben felhasználni.
+
+5. **Stixel világ előállítása**
+   A `config.yaml`-ban add meg az új adatútvonalat, majd indítsd el a
+   generálást:
+   ```bash
+   python generate.py
+   ```

--- a/README.md
+++ b/README.md
@@ -68,23 +68,29 @@ Az alábbi lépések segítenek egy rosbag állományból olyan nyers adatkészl
 
 3. **Üzenetek kinyerése**
    A `utility/rosbag_to_dataset.py` szkript képes a kiválasztott kép- és pontfelhő
-   topikokból fájlokat generálni:
+   topikokból fájlokat generálni. Például ZED2i bal kamera és Ouster LiDAR esetén:
    ```bash
    python utility/rosbag_to_dataset.py \
        --db output_bag.db3 \
-       --image_topic /camera/image/compressed \
-       --pc_topic /lidar/points \
+       --image_topic /zed2i/zed_node/left/image_rect_color/compressed \
+       --pc_topic /ouster/points \
        --out dataset_raw
    ```
    A kimenetként létrejövő `dataset_raw/images` és `dataset_raw/pointclouds`
    könyvtárakban JPEG képek és CSV formátumú pontfelhők lesznek elhelyezve.
 
-4. **Kalibrációk hozzáadása**
+4. **Kompatibilitás ellenőrzése**
+   A StixelGENerator Dataloader a JPEG képeket és a `x,y,z` koordinátákat tartalmazó
+   CSV-ket is képes kezelni, ha a kalibrációs mátrixok elérhetők. Ellenőrizd, hogy
+   mindkét mappában azonos számú fájl keletkezett, illetve hogy a pontfelhők a
+   szenzor specifikációinak megfelelően vannak kinyerve.
+
+5. **Kalibrációk hozzáadása**
    A generáláshoz szükséges a kamera–LiDAR kalibráció (K, P, extrinsic). Ezeket a
    rosbagből vagy a használt szenzorrendszer dokumentációjából kell kinyerni, és
    a saját adatbetöltőben felhasználni.
 
-5. **Stixel világ előállítása**
+6. **Stixel világ előállítása**
    A `config.yaml`-ban add meg az új adatútvonalat, majd indítsd el a
    generálást:
    ```bash

--- a/utility/rosbag_to_dataset.py
+++ b/utility/rosbag_to_dataset.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Extract images and point clouds from a ROS2 bag.
+
+This utility reads a rosbag2 SQLite database and writes each image and
+point cloud message into a separate file. The output can be used as the
+raw dataset for StixelGENerator after adding calibration information.
+"""
+import argparse
+import os
+import sqlite3
+from pathlib import Path
+import numpy as np
+
+POINT_STEP = 32
+OFFSETS = {"x": 0, "y": 4, "z": 8}
+
+
+def ensure_dir(path: str) -> None:
+    Path(path).mkdir(parents=True, exist_ok=True)
+
+
+def query_id(cur: sqlite3.Cursor, name: str):
+    cur.execute("SELECT id FROM topics WHERE name=?", (name,))
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def fetch_messages(cur: sqlite3.Cursor, tid: int):
+    cur.execute(
+        "SELECT timestamp, data FROM messages WHERE topic_id=? ORDER BY timestamp",
+        (tid,),
+    )
+    return cur.fetchall()
+
+
+def extract_images(msgs, out_dir: str) -> None:
+    ensure_dir(out_dir)
+    for ts, blob in msgs:
+        start = blob.find(b"\xff\xd8")
+        end = blob.rfind(b"\xff\xd9")
+        if start < 0 or end < 0:
+            continue
+        with open(os.path.join(out_dir, f"{ts}.jpg"), "wb") as f:
+            f.write(blob[start:end + 2])
+
+
+def extract_pointclouds(msgs, out_dir: str, step: int = POINT_STEP) -> None:
+    ensure_dir(out_dir)
+    for ts, blob in msgs:
+        hdr = next((i for i in range(1024) if (len(blob) - i) % step == 0), None)
+        if hdr is None:
+            continue
+        data = blob[hdr:]
+        pts = np.frombuffer(data, dtype=np.float32)
+        arr = pts.reshape(len(data) // step, step // 4)
+        xyz = arr[:, [OFFSETS["x"] // 4, OFFSETS["y"] // 4, OFFSETS["z"] // 4]]
+        np.savetxt(
+            os.path.join(out_dir, f"{ts}.csv"),
+            xyz,
+            delimiter=",",
+            header="x,y,z",
+            comments="",
+        )
+
+
+def list_topics(cur: sqlite3.Cursor):
+    cur.execute("SELECT name FROM topics")
+    return [row[0] for row in cur.fetchall()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert rosbag2 DB to dataset")
+    parser.add_argument("--db", required=True, help="sqlite3 bag file (*.db3)")
+    parser.add_argument("--image_topic", required=True, help="Image topic name")
+    parser.add_argument("--pc_topic", required=True, help="Pointcloud topic name")
+    parser.add_argument("--out", default="rosbag_dataset", help="Output directory")
+    args = parser.parse_args()
+
+    ensure_dir(args.out)
+
+    conn = sqlite3.connect(args.db)
+    cur = conn.cursor()
+
+    print("Available topics:")
+    for t in list_topics(cur):
+        print(" ", t)
+
+    tid = query_id(cur, args.image_topic)
+    if tid is not None:
+        msgs = fetch_messages(cur, tid)
+        extract_images(msgs, os.path.join(args.out, "images"))
+
+    tid = query_id(cur, args.pc_topic)
+    if tid is not None:
+        msgs = fetch_messages(cur, tid)
+        extract_pointclouds(msgs, os.path.join(args.out, "pointclouds"))
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `utility/rosbag_to_dataset.py` to extract images and point clouds from rosbag2 DB
- document rosbag conversion workflow in README

## Testing
- `python -m py_compile utility/rosbag_to_dataset.py`

------
https://chatgpt.com/codex/tasks/task_e_68776e06140483318090d978a12d6862