### PR TITLE
Add rosbag dataset loader and export fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ The following steps show how to extract a raw dataset from a rosbag so that it c
        --pc_topic /ouster/points \
        --out dataset_raw
    ```
-   The utility numbers the extracted messages consecutively. Each frame consists
-   of `images/<index>.jpg` and `pointclouds/<index>.csv`. A `dataset_map.csv`
-   file stores the original ROS timestamps so that the order can easily be
-   reconstructed later.
+   The utility numbers the extracted messages consecutively and keeps only
+   frames that contain both an image and a point cloud. Each pair is listed in
+   `dataset_map.csv` together with the original ROS timestamps so that the
+   capture order can be reconstructed later.
 
    The resulting folder tree therefore looks like:
 
@@ -114,8 +114,8 @@ The following steps show how to extract a raw dataset from a rosbag so that it c
    ```
 
 7. **Implement a dataloader**
-   The repository does not ship a generic loader for rosbag exports. Use the
-   provided `dataset_map.csv` as a starting point to write your own loader that
-   reads the images, loads the CSV point clouds and applies your calibration
-   matrices. Existing dataloaders in the `dataloader` directory can serve as
-   examples.
+   A simple loader named `RosbagDataLoader` is available to read this structure.
+   It expects a `calibration.yaml` next to `dataset_map.csv` containing the
+   camera matrices (K, P, R, T). You can use it directly by setting
+   `dataset: rosbag` in `config.yaml` or adapt it for your own needs. Existing
+   dataloaders in the `dataloader` directory can serve as examples.

--- a/dataloader/RosbagDataset.py
+++ b/dataloader/RosbagDataset.py
@@ -1,0 +1,69 @@
+import os
+import yaml
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from PIL import Image
+from typing import List
+
+from dataloader import BaseData, CameraInfo
+from libraries.Stixel import point_dtype
+
+
+class RosbagData(BaseData):
+    """Simple data container for datasets exported from rosbag."""
+
+    def __init__(self, name: str, img_path: str, pc_path: str, cam_info: CameraInfo):
+        super().__init__()
+        self.name = name
+        self.image = Image.open(img_path)
+        self.camera_info = cam_info
+
+        pts = np.loadtxt(pc_path, delimiter=",", skiprows=1)
+        pts_h = np.hstack([pts, np.ones((pts.shape[0], 1))])
+        proj = cam_info.P.dot(cam_info.R.dot(cam_info.T.dot(pts_h.T)))
+        proj[:2] /= proj[2, :]
+        proj = proj.T
+        sem_seg = np.zeros((pts.shape[0], 1))
+        combined = np.hstack([pts, proj, sem_seg])
+        self.points = np.array([tuple(row) for row in combined], dtype=point_dtype)
+
+
+class RosbagDataLoader:
+    """DataLoader for rosbag exports produced by ``rosbag_to_dataset.py``."""
+
+    def __init__(self, data_dir: str, first_only: bool = False):
+        self.name = "rosbag"
+        self.first_only = first_only
+        self.data_dir = data_dir
+        map_path = os.path.join(data_dir, "dataset_map.csv")
+        self.record_map = pd.read_csv(map_path)
+
+        calib_path = os.path.join(data_dir, "calibration.yaml")
+        if os.path.exists(calib_path):
+            with open(calib_path) as f:
+                calib_cfg = yaml.safe_load(f)
+            K = np.array(calib_cfg.get("K", np.eye(3)))
+            P = np.array(calib_cfg.get("P", np.hstack((K, np.zeros((3, 1))))) )
+            T = np.array(calib_cfg.get("T", np.eye(4)))
+            R = np.array(calib_cfg.get("R", np.eye(4)))
+        else:
+            K = np.eye(3)
+            P = np.hstack((K, np.zeros((3, 1))))
+            T = np.eye(4)
+            R = np.eye(4)
+        self.calib = CameraInfo(camera_mtx=K, trans_mtx=T, proj_mtx=P, rect_mtx=R)
+
+        first_img = Image.open(os.path.join(data_dir, self.record_map.loc[0, "image_file"]))
+        self.img_size = {"width": first_img.width, "height": first_img.height}
+
+    def __len__(self) -> int:
+        return len(self.record_map)
+
+    def __getitem__(self, idx: int) -> List[RosbagData]:
+        row = self.record_map.iloc[idx]
+        name = f"frame_{int(row['index']):06d}"
+        img_path = os.path.join(self.data_dir, row["image_file"])
+        pc_path = os.path.join(self.data_dir, row["pc_file"])
+        data = RosbagData(name, img_path, pc_path, self.calib)
+        return [data]

--- a/dataloader/__init__.py
+++ b/dataloader/__init__.py
@@ -3,3 +3,4 @@ from .KittiDataset import KittiDataLoader, KittiData
 from .CoopScenes import CoopSceneData, CoopScenesDataLoader
 # from .CityscapesDataset import CityscapesDataLoader, CityscapesData
 from .WaymoDataset import WaymoDataLoader, WaymoData
+from .RosbagDataset import RosbagDataLoader, RosbagData

--- a/generate.py
+++ b/generate.py
@@ -25,6 +25,8 @@ elif config['dataset'] == "kitti":
     from dataloader import KittiDataLoader as Dataset, KittiData as Data
 elif config['dataset'] == "aeif":
     from dataloader import CoopScenesDataLoader as Dataset, CoopSceneData as Data
+elif config['dataset'] == "rosbag":
+    from dataloader import RosbagDataLoader as Dataset, RosbagData as Data
 else:
     raise ValueError("Dataset not supported")
 overall_start_time = datetime.now()

--- a/utility/rosbag_to_dataset.py
+++ b/utility/rosbag_to_dataset.py
@@ -128,14 +128,14 @@ def main() -> None:
     map_file = os.path.join(args.out, "dataset_map.csv")
     with open(map_file, "w") as f:
         f.write("index,image_timestamp,image_file,pc_timestamp,pc_file\n")
-        length = max(len(img_map), len(pc_map))
+        length = min(len(img_map), len(pc_map))
+        if len(img_map) != len(pc_map):
+            print(
+                f"Warning: unmatched message counts - keeping {length} paired frames"
+            )
         for idx in range(length):
-            img_ts, img_file = ("", "")
-            pc_ts, pc_file = ("", "")
-            if idx < len(img_map):
-                _, img_ts, img_file = img_map[idx]
-            if idx < len(pc_map):
-                _, pc_ts, pc_file = pc_map[idx]
+            _, img_ts, img_file = img_map[idx]
+            _, pc_ts, pc_file = pc_map[idx]
             f.write(f"{idx},{img_ts},{img_file},{pc_ts},{pc_file}\n")
 
     conn.close()


### PR DESCRIPTION
## Summary
- ensure rosbag_to_dataset only keeps paired frames
- add `RosbagDataLoader` for using exported datasets
- integrate new loader in generator and dataloader package
- document usage of the loader

## Testing
- `python -m compileall -q generate.py dataloader utility`


------
https://chatgpt.com/codex/tasks/task_e_687775617974833182b56552bee5cbd4