### PR TITLE
Handle optional Kitti dataset

### DIFF
--- a/dataloader/__init__.py
+++ b/dataloader/__init__.py
@@ -1,6 +1,19 @@
 from .BaseClasses import BaseData, CameraInfo, Pose
-from .KittiDataset import KittiDataLoader, KittiData
+try:
+    from .KittiDataset import KittiDataLoader, KittiData
+    KITTI_IMPORT_ERROR = None
+except ModuleNotFoundError as err:
+    KittiDataLoader = None  # type: ignore
+    KittiData = None  # type: ignore
+    KITTI_IMPORT_ERROR = err
 from .CoopScenes import CoopSceneData, CoopScenesDataLoader
 # from .CityscapesDataset import CityscapesDataLoader, CityscapesData
-from .WaymoDataset import WaymoDataLoader, WaymoData
 from .RosbagDataset import RosbagDataLoader, RosbagData
+
+try:
+    from .WaymoDataset import WaymoDataLoader, WaymoData
+    WAYMO_IMPORT_ERROR = None
+except ModuleNotFoundError as err:
+    WaymoDataLoader = None  # type: ignore
+    WaymoData = None  # type: ignore
+    WAYMO_IMPORT_ERROR = err

--- a/generate.py
+++ b/generate.py
@@ -20,9 +20,19 @@ from libraries import remove_far_points, remove_ground, StixelGenerator, Stixel,
 with open('config.yaml') as yaml_file:
     config = yaml.load(yaml_file, Loader=yaml.FullLoader)
 if config['dataset'] == "waymo":
-    from dataloader import WaymoDataLoader as Dataset, WaymoData as Data
+    from dataloader import WaymoDataLoader as Dataset, WaymoData as Data, WAYMO_IMPORT_ERROR
+    if Dataset is None:
+        raise ModuleNotFoundError(
+            "Waymo dataset support requires the 'waymo-open-dataset' package. "
+            "Install it via 'pip install waymo-open-dataset-tf-2-12-0'."
+        ) from WAYMO_IMPORT_ERROR
 elif config['dataset'] == "kitti":
-    from dataloader import KittiDataLoader as Dataset, KittiData as Data
+    from dataloader import KittiDataLoader as Dataset, KittiData as Data, KITTI_IMPORT_ERROR
+    if Dataset is None:
+        raise ModuleNotFoundError(
+            "Kitti dataset support requires the 'pykitti' package. "
+            "Install it via 'pip install pykitti'."
+        ) from KITTI_IMPORT_ERROR
 elif config['dataset'] == "aeif":
     from dataloader import CoopScenesDataLoader as Dataset, CoopSceneData as Data
 elif config['dataset'] == "rosbag":

--- a/utility/explore.py
+++ b/utility/explore.py
@@ -1,5 +1,3 @@
-from dataloader import WaymoDataLoader as Dataset
-from dataloader.WaymoDataset import show_projected_camera_synced_boxes
 from libraries import *
 import open3d as o3d
 import numpy as np
@@ -10,9 +8,19 @@ from libraries.Stixel import point_dtype_ext
 with open('config.yaml') as yaml_file:
     config = yaml.load(yaml_file, Loader=yaml.FullLoader)
 if config['dataset'] == "waymo":
-    from dataloader import WaymoDataLoader as Dataset, WaymoData as Data
+    from dataloader import WaymoDataLoader as Dataset, WaymoData as Data, WAYMO_IMPORT_ERROR
+    if Dataset is None:
+        raise ModuleNotFoundError(
+            "Waymo dataset support requires the 'waymo-open-dataset' package. "
+            "Install it via 'pip install waymo-open-dataset-tf-2-12-0'."
+        ) from WAYMO_IMPORT_ERROR
 elif config['dataset'] == "kitti":
-    from dataloader import KittiDataLoader as Dataset, KittiData as Data
+    from dataloader import KittiDataLoader as Dataset, KittiData as Data, KITTI_IMPORT_ERROR
+    if Dataset is None:
+        raise ModuleNotFoundError(
+            "Kitti dataset support requires the 'pykitti' package. "
+            "Install it via 'pip install pykitti'."
+        ) from KITTI_IMPORT_ERROR
 elif config['dataset'] == "aeif":
     from dataloader import CoopScenesDataLoader as Dataset, CoopSceneData as Data
 else:


### PR DESCRIPTION
## Summary
- avoid failing import when `pykitti` isn't installed
- show clear instructions if the Kitti loader is selected
- keep the same behavior for the Waymo loader

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt` *(fails: Getting requirements to build wheel did not run successfully)*


------
https://chatgpt.com/codex/tasks/task_e_68809717163083319f36e53ea35df27f