### PR TITLE
Fix C long overflow in rosbag loader

### DIFF
--- a/dataloader/RosbagDataset.py
+++ b/dataloader/RosbagDataset.py
@@ -35,6 +35,9 @@ class RosbagData(BaseData):
         valid_mask = np.isfinite(proj).all(axis=1)
         proj = proj[valid_mask]
         pts = pts[valid_mask]
+        # Clip projected points into signed 32-bit integer range
+        i32_min, i32_max = -(2 ** 31), 2 ** 31 - 1
+        proj = np.clip(proj, i32_min, i32_max).astype(int)
         sem_seg = np.zeros((pts.shape[0], 1))
         combined = np.hstack([pts, proj, sem_seg])
         self.points = np.array([tuple(row) for row in combined], dtype=point_dtype)

--- a/dataloader/__init__.py
+++ b/dataloader/__init__.py
@@ -6,7 +6,13 @@ except ModuleNotFoundError as err:
     KittiDataLoader = None  # type: ignore
     KittiData = None  # type: ignore
     KITTI_IMPORT_ERROR = err
-from .CoopScenes import CoopSceneData, CoopScenesDataLoader
+try:
+    from .CoopScenes import CoopSceneData, CoopScenesDataLoader
+    COOPSCENES_IMPORT_ERROR = None
+except ModuleNotFoundError as err:
+    CoopScenesDataLoader = None  # type: ignore
+    CoopSceneData = None  # type: ignore
+    COOPSCENES_IMPORT_ERROR = err
 # from .CityscapesDataset import CityscapesDataLoader, CityscapesData
 from .RosbagDataset import RosbagDataLoader, RosbagData
 


### PR DESCRIPTION
## Summary
- avoid mandatory CoopScenes import so missing dependencies don't block execution
- clamp rosbag projection results to int32

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880b5f485c0833184c745330dc4b95b