### PR TITLE
Fix int overflow in Rosbag loader

### DIFF
--- a/dataloader/RosbagDataset.py
+++ b/dataloader/RosbagDataset.py
@@ -37,7 +37,7 @@ class RosbagData(BaseData):
         pts = pts[valid_mask]
         # Clip projected points into signed 32-bit integer range
         i32_min, i32_max = -(2 ** 31), 2 ** 31 - 1
-        proj = np.clip(proj, i32_min, i32_max).astype(int)
+        proj = np.clip(proj, i32_min, i32_max).astype(np.int32)
         sem_seg = np.zeros((pts.shape[0], 1))
         combined = np.hstack([pts, proj, sem_seg])
         self.points = np.array([tuple(row) for row in combined], dtype=point_dtype)


### PR DESCRIPTION
## Summary
- ensure projected pixel values use int32 to avoid overflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ce6337648331a7ef51f532a6b4fe