### PR TITLE
Fix visualization CLI for external usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,17 @@ The following steps show how to extract a raw dataset from a rosbag so that it c
    python generate.py
    ```
 
-8. **Implement a dataloader**
+8. **Visualize Stixel Worlds**
+   Use `utility/image_visualization_cli.py` to overlay an existing `.stx1` file
+   on an image:
+   ```bash
+   python utility/image_visualization_cli.py --image path/to/image.jpg \
+       --stx path/to/world.stx1 --out overlay.png
+   ```
+   If you run the script from outside the repository specify the repo root with
+   `--root /path/to/StixelGENerator`.
+
+9. **Implement a dataloader**
    A simple loader named `RosbagDataLoader` is available to read this structure.
    It expects a `calibration.yaml` next to `dataset_map.csv` containing the
    camera matrices (K, P, R, T). You can use it directly by setting

--- a/libraries/visualization.py
+++ b/libraries/visualization.py
@@ -3,9 +3,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import patches
 from typing import List, Tuple, Dict, Optional
-from libraries import StixelClass
+from libraries.Stixel import Stixel, StixelClass
 import cv2
-from libraries.Stixel import Stixel
 
 
 def _to_int32(value: int) -> int:

--- a/utility/image_visualization_cli.py
+++ b/utility/image_visualization_cli.py
@@ -16,16 +16,6 @@ import types
 import numpy as np
 from PIL import Image
 
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.append(str(ROOT))
-
-def _load_module(name: str, path: Path):
-    spec = importlib.util.spec_from_file_location(name, path)
-    module = importlib.util.module_from_spec(spec)
-    assert spec and spec.loader
-    spec.loader.exec_module(module)
-    return module
-
 try:  # pyStixel-lib provides the stixel package
     import stixel  # type: ignore
 except ImportError as exc:  # pragma: no cover - library not installed
@@ -34,46 +24,58 @@ except ImportError as exc:  # pragma: no cover - library not installed
         " Install it with 'pip install pyStixel-lib'."
     ) from exc
 
-Stixel_mod = _load_module("libraries.Stixel", ROOT / "libraries" / "Stixel.py")
-
-dummy = types.ModuleType("libraries")
-dummy.StixelClass = Stixel_mod.StixelClass
-dummy.Stixel = Stixel_mod.Stixel
-sys.modules.setdefault("libraries", dummy)
-sys.modules.setdefault("libraries.Stixel", Stixel_mod)
-
-Viz_mod = _load_module("libraries.visualization", ROOT / "libraries" / "visualization.py")
-
-Stixel = Stixel_mod.Stixel
-StixelClass = Stixel_mod.StixelClass
-point_dtype = Stixel_mod.point_dtype
-draw_stixels_on_image = Viz_mod.draw_stixels_on_image
+DEFAULT_ROOT = Path(__file__).resolve().parents[1]
 
 
-def _to_stixels(world: 'stixel.StixelWorld') -> Tuple[List[Stixel], int]:
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _prepare_libraries(root: Path):
+    """Load visualization helpers from ``root``."""
+    sys.path.append(str(root))
+    stixel_mod = _load_module("libraries.Stixel", root / "libraries" / "Stixel.py")
+
+    dummy = types.ModuleType("libraries")
+    dummy.__path__ = [str(root / "libraries")]
+    dummy.StixelClass = stixel_mod.StixelClass
+    dummy.Stixel = stixel_mod.Stixel
+    sys.modules.setdefault("libraries", dummy)
+    sys.modules.setdefault("libraries.Stixel", stixel_mod)
+
+    viz_mod = _load_module("libraries.visualization", root / "libraries" / "visualization.py")
+
+    return stixel_mod, viz_mod
+
+
+def _to_stixels(
+    world: "stixel.StixelWorld", img_size: dict, stixel_mod
+) -> Tuple[List[object], int]:
     """Convert a ``stixel.StixelWorld`` to a list of local ``Stixel`` objects.
 
     Parameters
     ----------
     world:
-        Parsed ``StixelWorld`` protobuf.
-
-    Returns
-    -------
-    tuple
-        The list of converted stixels and the grid width to use when drawing.
+        Parsed ``stixel.StixelWorld`` protobuf.
+    img_size:
+        ``{"width": int, "height": int}`` dictionary describing the size of the
+        image used for visualization. The dimensions inside the stixel file may
+        be invalid, so use the actual image size instead.
+    stixel_mod:
+        Loaded ``libraries.Stixel`` module providing the ``Stixel`` class.
     """
-    img_size = {
-        'width': world.context.calibration.width,
-        'height': world.context.calibration.height,
-    }
-    stixels: List[Stixel] = []
+    Stixel = stixel_mod.Stixel
+    StixelClass = stixel_mod.StixelClass
+    point_dtype = stixel_mod.point_dtype
+    stixels: List[object] = []
     width = world.stixel[0].width if world.stixel else 8
     for stx in world.stixel:
-        top_pt = np.array((0.0, 0.0, 0.0, stx.u, stx.vT, stx.d, stx.label),
-                          dtype=point_dtype)
-        bot_pt = np.array((0.0, 0.0, 0.0, stx.u, stx.vB, stx.d, stx.label),
-                          dtype=point_dtype)
+        top_pt = np.array((0.0, 0.0, 0.0, stx.u, stx.vT, stx.d, stx.label), dtype=point_dtype)
+        bot_pt = np.array((0.0, 0.0, 0.0, stx.u, stx.vB, stx.d, stx.label), dtype=point_dtype)
         stixels.append(
             Stixel(top_pt, bot_pt, StixelClass.OBJECT, img_size, grid_step=stx.width)
         )
@@ -82,16 +84,27 @@ def _to_stixels(world: 'stixel.StixelWorld') -> Tuple[List[Stixel], int]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Visualize a StixelWorld on a given image")
+        description="Visualize a StixelWorld on a given image"
+    )
     parser.add_argument("--image", required=True, help="Input JPEG image")
     parser.add_argument("--stx", required=True, help="StixelWorld .stx1 file")
     parser.add_argument("--out", help="Path to save the overlay image")
+    parser.add_argument(
+        "--root",
+        default=str(DEFAULT_ROOT),
+        help="Path to repository root containing the 'libraries' directory",
+    )
     args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    stixel_mod, viz_mod = _prepare_libraries(root)
 
     img = Image.open(args.image)
     stxl_world = stixel.read(args.stx)
-    stixels, width = _to_stixels(stxl_world)
-    result = draw_stixels_on_image(
+    img_size = {"width": img.width, "height": img.height}
+    stixels, width = _to_stixels(stxl_world, img_size, stixel_mod)
+
+    result = viz_mod.draw_stixels_on_image(
         np.array(img), stixels, stixel_width=width, draw_grid=False
     )
 
@@ -105,3 +118,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- add --root option to `image_visualization_cli.py`
- avoid heavy open3d dependency when visualizing
- document how to visualize stixel worlds
- fix stixel visualization image sizing

## Testing
- `python -m py_compile utility/image_visualization_cli.py libraries/visualization.py`
- `python utility/image_visualization_cli.py --image 17065833287841703_2980_000_3000_000_165_FRONT.png --stx 17065833287841703_2980_000_3000_000_165_FRONT.stx1 --out overlay_test.png`
- `python utility/image_visualization_cli.py --image 17065833287841703_2980_000_3000_000_165_FRONT.png --stx 17065833287841703_2980_000_3000_000_165_FRONT.stx1 --out overlay_test2.png --root /workspace/StixelGENerator`

------
https://chatgpt.com/codex/tasks/task_e_6889ec6f8f9c8331a7f272cfc6756063